### PR TITLE
feat: Add vignette for chunking scientific papers

### DIFF
--- a/VIGNETTE.md
+++ b/VIGNETTE.md
@@ -1,0 +1,310 @@
+# A Developer's Guide to Chunking Scientific Papers at Scale
+
+## Introduction
+
+In any Retrieval-Augmented Generation (RAG) pipeline, the quality of the retrieval mechanism is paramount. At the heart of this mechanism lies a seemingly simple but critically important step: **document chunking**. Chunking is the process of breaking down large documents into smaller, semantically coherent segments. The goal is to create chunks that are small enough to fit into an embedding model's context window and focused enough to yield precise results during a vector search. When a user asks a question, we want to retrieve only the most relevant snippets of text, not entire documents.
+
+Scientific papers present a unique and demanding challenge for this process. Unlike simple prose, they are dense, highly structured documents, rich with semantic and syntactic complexity. They contain elements that must be preserved and understood in context, such as:
+
+*   **Hierarchical Structure**: Sections, sub-sections, and sub-sub-sections (e.g., `1. Introduction`, `1.1 Background`, `2. Methods`).
+*   **Complex Data Formats**: Tables, code blocks, and mathematical formulas.
+*   **Rich Metadata**: Citations, figures, and footnotes that are crucial for context.
+
+A naive approach, such as **fixed-size chunking**, is often inadequate for this task. Simply splitting a document every `N` characters will inevitably break tables in half, sever code blocks from their explanations, and disregard the logical flow of an argument. The result is a set of disjointed, context-poor chunks that poison the retrieval process.
+
+To overcome these challenges, developers must employ more intelligent, **structure-aware chunking methods**. These techniques are designed to respect the document's intrinsic structure, using Markdown headers, newlines, and other semantic boundaries as natural splitting points. By aligning chunks with the logical sections of a paper, we can ensure that each chunk is a self-contained, meaningful unit of information, perfectly primed for accurate embedding and retrieval. This guide will walk you through the strategies and code required to implement such a sophisticated chunking pipeline at scale.
+
+## Setup & Prerequisites
+
+Before we dive into the code, you need to set up your environment and install the necessary libraries. This guide assumes you are working with a dataset of scientific articles that have already been converted from PDF to Markdown.
+
+The core of our pipeline will be the `advanced-text-segmentation` package, which provides the specialized chunking strategies we need. We will also need `unstructured` for loading Markdown files, `langchain` as a high-level framework, and `tiktoken` for accurate token counting.
+
+You can install all required packages with the following command:
+
+```bash
+pip install "unstructured[md]" langchain tiktoken
+pip install .[markdown,tokenizers,semantic]
+```
+
+*   `unstructured[md]`: A powerful library for parsing and loading documents in various formats, here with the extra dependencies for Markdown.
+*   `langchain`: A popular framework for building LLM applications, which we'll use for high-level abstractions.
+*   `tiktoken`: OpenAI's fast BPE tokenizer, crucial for ensuring our chunks do not exceed the token limits of models like GPT-4.
+*   `.[markdown,tokenizers,semantic]`: This installs the local `advanced-text-segmentation` package along with the optional extras needed for Markdown parsing, `tiktoken` integration, and semantic chunking.
+
+## Strategy 1: Structure-Aware Splitting with `MarkdownSplitter`
+
+The most reliable way to chunk a scientific paper in Markdown format is to use a strategy that understands the document's structure. The `MarkdownSplitter` from the `advanced-text-segmentation` package is designed for this exact purpose.
+
+This splitter parses the Markdown and identifies logical boundaries based on its hierarchical structure. It prioritizes splitting at the highest-level headings (e.g., between `# H1` and `# H2` sections) before moving to finer-grained elements. This ensures that the generated chunks correspond to logical sections of the paper, such as the abstract, introduction, or specific methods, preserving their context.
+
+If a single section is still too large to fit within the specified `chunk_size`, the `MarkdownSplitter` automatically falls back to a `RecursiveCharacterSplitter` to subdivide that section, ensuring no chunk exceeds the token limit.
+
+Let's see it in action. First, we need a sample document. Assume you have a file named `sample_paper.md` in your directory with typical academic content.
+
+Now, let's write a script to load and chunk this document. We'll configure the splitter with a token-based length function to prepare the chunks for a modern embedding model.
+
+```python
+import json
+from langchain_community.document_loaders import UnstructuredMarkdownLoader
+from text_segmentation.strategies.structure.markdown import MarkdownSplitter
+from text_segmentation.tokenizers import from_tiktoken
+
+# --- 1. Load the Document ---
+# We use UnstructuredMarkdownLoader, which is effective at parsing complex
+# Markdown files like those converted from scientific PDFs.
+loader = UnstructuredMarkdownLoader("sample_paper.md")
+document = loader.load()[0]
+
+# --- 2. Configure a Token-Aware Length Function ---
+# To ensure our chunks are sized correctly for the embedding model,
+# we measure length in tokens, not characters. We'll use the tokenizer
+# for BAAI/bge-large-en-v1.5, which corresponds to "cl100k_base".
+length_function = from_tiktoken("cl100k_base")
+
+# --- 3. Initialize the Structure-Aware Splitter ---
+# We initialize the MarkdownSplitter with a target chunk size of 512 tokens
+# and an overlap of 100 tokens. The overlap helps maintain context
+# between adjacent chunks.
+splitter = MarkdownSplitter(
+    chunk_size=512,
+    chunk_overlap=100,
+    length_function=length_function
+)
+
+# --- 4. Chunk the Document ---
+# The splitter processes the text and returns a list of `Chunk` objects.
+# Each chunk contains not only the text content but also rich metadata.
+chunks = splitter.split_text(document.page_content)
+
+# --- 5. Inspect the Output ---
+# Let's examine the generated chunks and their metadata.
+print(f"Original document length: {length_function(document.page_content)} tokens")
+print(f"Total chunks generated: {len(chunks)}\n")
+
+for i, chunk in enumerate(chunks):
+    chunk_dict = chunk.to_dict()
+    # The 'hierarchical_context' metadata is populated by the MarkdownSplitter.
+    # It shows the section headers this chunk belongs to.
+    context = chunk_dict.get("hierarchical_context", {})
+
+    print(f"--- Chunk {i+1} ---")
+    print(f"Token Count: {length_function(chunk.content)}")
+    print(f"Hierarchical Context: {context}")
+    print(f"Content:\n{chunk.content}\n")
+
+# You can also save the structured output to a file for later use.
+output_data = [chunk.to_dict() for chunk in chunks]
+with open("chunked_output_strategy_1.json", "w") as f:
+    json.dump(output_data, f, indent=2)
+
+print("Chunked output saved to 'chunked_output_strategy_1.json'")
+```
+
+When you run this script, you'll notice that the chunks are logically divided. For example, the "Abstract" will likely be in its own chunk, and the "Methods" section will be chunked separately from the "Results," with the `hierarchical_context` metadata clearly indicating where each chunk came from. This structural integrity is vital for high-quality retrieval.
+
+## Strategy 2: Advanced Semantic Chunking
+
+While structure-aware splitting is a massive improvement over naive methods, **semantic chunking** takes it a step further. Instead of relying on document markers like headers, this strategy analyzes the *meaning* of the text itself to find the most logical breakpoints.
+
+The `SemanticSplitter` works by following a clever process:
+1.  It first splits the document into individual sentences.
+2.  It then uses a sentence-transformer model (which you provide) to convert each sentence into a numerical vector, or "embedding."
+3.  It calculates the cosine similarity between the embeddings of adjacent sentences. A high similarity score means the sentences are topically related, while a sudden drop in similarity indicates a shift in topic.
+4.  It identifies these drops as "breakpoints" and splits the text there, creating chunks that are highly focused and semantically coherent.
+
+This approach is powerful because it can find logical divisions even within a single, long paragraph that lacks any structural separators.
+
+Let's adapt our previous example to use the `SemanticSplitter`. For this to work, you'll need an embedding model. We recommend a high-performance model like `BAAI/bge-large-en-v1.5`.
+
+```python
+import json
+import numpy as np
+from langchain_community.document_loaders import UnstructuredMarkdownLoader
+from text_segmentation.strategies.semantic import SemanticSplitter
+from text_segmentation.tokenizers import from_tiktoken
+
+# --- (Prerequisite) Setup an Embedding Function ---
+# The SemanticSplitter requires a function that can turn a list of texts
+# into a list of numerical embeddings. We'll set up a dummy function
+# for this example, but in a real application, you would use a real
+# sentence-transformer model.
+#
+# from sentence_transformers import SentenceTransformer
+# model = SentenceTransformer('BAAI/bge-large-en-v1.5')
+# def embedding_function(texts: list[str]) -> list[list[float]]:
+#     return model.encode(texts).tolist()
+
+# For demonstration, we'll use a placeholder that returns random vectors.
+def dummy_embedding_function(texts: list[str]) -> list[list[float]]:
+    print(f"Embedding {len(texts)} texts...")
+    return np.random.rand(len(texts), 768).tolist()
+
+
+# --- 1. Load the Document ---
+loader = UnstructuredMarkdownLoader("sample_paper.md")
+document = loader.load()[0]
+text = document.page_content
+
+# --- 2. Initialize the Semantic Splitter ---
+# We provide our embedding function to the splitter.
+# The 'breakpoint_threshold' determines how significant a semantic shift
+# must be to trigger a split. We can set it based on a percentile of
+# similarity scores, a standard deviation, or an absolute value.
+# Using "percentile" is often a robust choice.
+splitter = SemanticSplitter(
+    embedding_function=dummy_embedding_function,
+    breakpoint_method="percentile",
+    breakpoint_threshold=95,  # Split at the 95th percentile of similarity gaps.
+    chunk_size=512, # Max chunk size (in tokens) as a fallback.
+    length_function=from_tiktoken("cl100k_base")
+)
+
+# --- 3. Chunk the Document ---
+chunks = splitter.split_text(text)
+
+# --- 4. Inspect the Output ---
+print(f"Total chunks generated: {len(chunks)}\n")
+
+for i, chunk in enumerate(chunks):
+    print(f"--- Chunk {i+1} (Size: {len(chunk.content)} chars) ---")
+    print(f"{chunk.content}\n")
+
+# Save the output for inspection
+output_data = [chunk.to_dict() for chunk in chunks]
+with open("chunked_output_strategy_2.json", "w") as f:
+    json.dump(output_data, f, indent=2)
+
+print("Chunked output saved to 'chunked_output_strategy_2.json'")
+```
+
+Because this method groups sentences by their topic, the resulting chunks are exceptionally coherent. This can lead to superior performance in RAG systems, as the information retrieved for a user's query will be more focused and less likely to contain irrelevant noise from adjacent but unrelated topics.
+
+## Building a Scalable Processing Pipeline
+
+Running these chunking strategies on a single file is straightforward. However, real-world RAG applications often involve processing thousands or even millions of documents. To handle this scale, we need to build a robust, parallelized pipeline.
+
+This final section provides a complete, runnable Python script that demonstrates how to apply the `MarkdownSplitter` to an entire directory of scientific papers. It uses Python's `concurrent.futures` module to process multiple documents in parallel, significantly speeding up the workflow.
+
+The pipeline will:
+1.  Scan a target directory for all Markdown (`.md`) files.
+2.  Create a pool of worker processes to handle multiple files concurrently.
+3.  For each file, load its content, chunk it using the `MarkdownSplitter`, and enrich the chunks with the source filename.
+4.  Aggregate all the resulting chunks from all documents into a single list.
+5.  Save the final, structured output as a single JSON file, ready for the next stage of your RAG pipeline (e.g., embedding and indexing).
+
+To run this, save the following code as a Python file (e.g., `process_papers.py`) in your project's root directory. Create a directory named `dataset` and place your Markdown files inside it (e.g., `paper_1.md`, `paper_2.md`, etc.).
+
+```python
+import os
+import json
+import concurrent.futures
+from pathlib import Path
+from typing import List, Dict, Any
+
+from langchain_community.document_loaders import UnstructuredMarkdownLoader
+from text_segmentation.strategies.structure.markdown import MarkdownSplitter
+from text_segmentation.tokenizers import from_tiktoken
+from text_segmentation.core import Chunk
+
+def get_markdown_files(directory: Path) -> List[Path]:
+    """Finds all Markdown files in a directory."""
+    return list(directory.glob("*.md"))
+
+def process_document(filepath: Path, splitter: MarkdownSplitter) -> List[Dict[str, Any]]:
+    """
+    Loads a single Markdown document, chunks it, and returns a list of
+    chunk dictionaries, enriched with the source filename.
+    """
+    print(f"Processing: {filepath.name}")
+    try:
+        # Load the document using UnstructuredMarkdownLoader
+        loader = UnstructuredMarkdownLoader(str(filepath))
+        doc = loader.load()[0]
+
+        # Chunk the document's content
+        chunks = splitter.split_text(doc.page_content)
+
+        # Enrich each chunk with the source filename and convert to dict
+        chunk_dicts = []
+        for chunk in chunks:
+            chunk_dict = chunk.to_dict()
+            # Add the source filename to the metadata
+            chunk_dict["metadata"]["source_filename"] = filepath.name
+            chunk_dicts.append(chunk_dict)
+
+        return chunk_dicts
+    except Exception as e:
+        print(f"Error processing {filepath.name}: {e}")
+        return []
+
+def main():
+    """
+    Main function to orchestrate the parallel processing of Markdown documents.
+    """
+    # --- Configuration ---
+    # Directory containing the Markdown files of scientific papers
+    input_directory = Path("dataset")
+    # File to save the final chunked output
+    output_file = Path("chunked_scientific_papers.json")
+    # Number of parallel processes to use
+    max_workers = os.cpu_count() or 1
+
+    print("--- Starting Scalable Chunking Pipeline ---")
+    print(f"Input directory: '{input_directory}'")
+    print(f"Output file: '{output_file}'")
+    print(f"Using {max_workers} worker processes.")
+
+    # --- 1. Discover Files ---
+    markdown_files = get_markdown_files(input_directory)
+    if not markdown_files:
+        print("No Markdown files found in the directory. Exiting.")
+        return
+    print(f"Found {len(markdown_files)} Markdown files to process.")
+
+    # --- 2. Initialize Splitter ---
+    # We'll use the robust MarkdownSplitter, configured for token-based chunking.
+    length_function = from_tiktoken("cl100k_base")
+    splitter = MarkdownSplitter(
+        chunk_size=512,
+        chunk_overlap=100,
+        length_function=length_function,
+        # Keep Markdown elements like headers in the chunk content
+        strip_markdown=False
+    )
+
+    # --- 3. Process Files in Parallel ---
+    all_chunks = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        # Create a future for each document processing task
+        future_to_file = {
+            executor.submit(process_document, filepath, splitter): filepath
+            for filepath in markdown_files
+        }
+
+        for future in concurrent.futures.as_completed(future_to_file):
+            filepath = future_to_file[future]
+            try:
+                # Retrieve the list of chunks from the completed future
+                chunks_from_file = future.result()
+                all_chunks.extend(chunks_from_file)
+                print(f"Successfully processed and chunked: {filepath.name}")
+            except Exception as e:
+                print(f"An exception occurred while processing {filepath.name}: {e}")
+
+    # --- 4. Save Combined Output ---
+    print(f"\nTotal chunks generated from all documents: {len(all_chunks)}")
+
+    # Sort the chunks by source filename and then by sequence number
+    all_chunks.sort(key=lambda x: (x["metadata"]["source_filename"], x["sequence_number"]))
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(all_chunks, f, indent=2, ensure_ascii=False)
+
+    print(f"Pipeline complete. All chunks saved to '{output_file}'.")
+
+if __name__ == "__main__":
+    main()
+```
+
+This script provides a production-ready template for preprocessing a large corpus of documents. By parallelizing the workload, it ensures that you can efficiently prepare your data, even as your dataset grows, laying a solid foundation for a high-performing RAG system.

--- a/dataset/paper_2.md
+++ b/dataset/paper_2.md
@@ -1,0 +1,10 @@
+# A Study on the Effects of Climate Change on Coral Reefs
+
+## Abstract
+This paper analyzes the impact of rising ocean temperatures on coral bleaching events over the past decade. We present a longitudinal study of the Great Barrier Reef.
+
+## 1. Introduction
+Coral reefs are vital marine ecosystems. They are currently under threat from anthropogenic climate change.
+
+## 2. Data Collection
+Data was collected from 2013 to 2023 using satellite imagery and in-situ temperature sensors. Over 500 distinct reef sites were monitored.

--- a/dataset/paper_3.md
+++ b/dataset/paper_3.md
@@ -1,0 +1,10 @@
+# Machine Learning for Drug Discovery
+
+## Abstract
+We explore the use of Graph Neural Networks (GNNs) for predicting molecular properties, accelerating the process of drug discovery. Our model, MolGNN, achieves state-of-the-art results on the ZINC dataset.
+
+## 1. Background
+Traditional drug discovery is a costly and time-consuming process. Machine learning offers a promising alternative by enabling high-throughput virtual screening of chemical compounds.
+
+### 1.1 Graph Neural Networks
+GNNs are a class of deep learning methods designed to perform inference on data described by graphs. They are a natural fit for modeling molecules, which can be represented as molecular graphs.

--- a/sample_paper.md
+++ b/sample_paper.md
@@ -1,0 +1,40 @@
+# Abstract
+This paper introduces a novel method for quantum key distribution. We demonstrate a new protocol that is resistant to common eavesdropping attacks.
+
+# 1. Introduction
+Quantum Key Distribution (QKD) is a secure communication method that implements a cryptographic protocol involving components of quantum mechanics. It enables two parties to produce a shared random secret key known only to them, which can then be used to encrypt and decrypt messages.
+
+## 1.1 Prior Work
+Existing QKD protocols, such as BB84, are theoretically secure. However, their implementation in real-world devices can be vulnerable to side-channel attacks. Our work builds upon the foundations laid by these pioneering protocols.
+
+# 2. Methods
+Our proposed protocol, which we call the "Resistant QKD Protocol" (RQP), uses a three-state system instead of the traditional two-state system.
+
+The core of the RQP is the following algorithm:
+```python
+def resistant_qkd_protocol(alice_basis, bob_basis):
+    # Simulate the quantum channel
+    alice_qubits = prepare_qubits(alice_basis)
+    # Eavesdropper interaction would be modeled here
+    measured_qubits = measure_qubits(alice_qubits, bob_basis)
+    return sift_keys(measured_qubits)
+```
+
+## 2.1 Experimental Setup
+The experiment was conducted using a fiber-optic cable network spanning 50 kilometers. A single-photon detector with a 99.5% efficiency was used.
+
+### 2.1.1 Error Correction
+We applied a Low-Density Parity-Check (LDPC) code for error correction, which proved to be highly efficient.
+
+# 3. Results
+The RQP achieved a secure key rate of 1.2 kbps over the 50km distance, which is a significant improvement over existing methods under similar conditions.
+
+The results are summarized in the table below:
+
+| Protocol | Distance (km) | Key Rate (kbps) |
+|----------|---------------|-----------------|
+| BB84     | 50            | 0.4             |
+| RQP      | 50            | 1.2             |
+
+# 4. Conclusion
+The Resistant QKD Protocol offers a more secure and efficient method for quantum key distribution. Future work will involve testing the protocol over longer distances and with different types of optical fiber.


### PR DESCRIPTION
This commit introduces a new comprehensive programming vignette titled: "A Developer's Guide to Chunking Scientific Papers at Scale."

The vignette serves as a practical guide for developers working with RAG pipelines on how to preprocess and chunk dense, structured documents like scientific articles.

Key additions include:
- A new `VIGNETTE.md` file containing the full guide.
- Detailed explanations and runnable code examples for two chunking strategies: structure-aware `MarkdownSplitter` and `SemanticSplitter`.
- A complete, parallelized Python script for processing a directory of papers at scale using `concurrent.futures`.
- Sample Markdown files (`sample_paper.md`, `dataset/paper_2.md`, `dataset/paper_3.md`) to support the runnable examples.